### PR TITLE
Fixed compilation issue with kapitan version 0.27.0

### DIFF
--- a/example-3/compiled/dev-sea/manifests/tuna-deployment.yml
+++ b/example-3/compiled/dev-sea/manifests/tuna-deployment.yml
@@ -13,7 +13,7 @@ spec:
       containers:
         - args:
             - --verbose=True
-            - --secret=?{ref:targets/dev-sea/tuna:ee958e1c}
+            - --secret=?{plain:$PWD/secrets/targets/dev-sea/tuna|randomstr}
             - --brine
             - --canned
           image: alledm/tuna:v2.0.0

--- a/example-3/compiled/prod-sea/manifests/tuna-deployment.yml
+++ b/example-3/compiled/prod-sea/manifests/tuna-deployment.yml
@@ -13,7 +13,7 @@ spec:
       containers:
         - args:
             - --verbose=False
-            - --secret=?{ref:targets/prod-sea/tuna:7d3096e2}
+            - --secret=?{plain:$PWD/secrets/targets/prod-sea/tuna|randomstr}
             - --brine
             - --canned
           image: alledm/tuna:v2.0.0

--- a/example-3/inventory/classes/components/tuna.yml
+++ b/example-3/inventory/classes/components/tuna.yml
@@ -7,7 +7,7 @@ parameters:
     replicas: ${replicas}
     args:
     - --verbose=${verbose}
-    - --secret=?{ref:targets/${target}/tuna|randomstr}
+    - --secret=?{plain:$PWD/secrets/targets/${target}/tuna|randomstr}
 
   kapitan:
     mains:

--- a/example-3/secrets/targets/dev-sea/tuna
+++ b/example-3/secrets/targets/dev-sea/tuna
@@ -1,3 +1,3 @@
 data: bHRKVFRIV3FvRnBUSWdSWTFHb01qcW9oR2d4MkRGelhMQ2FERzN6WHJ0MA==
 encoding: original
-type: ref
+type: plain

--- a/example-3/secrets/targets/prod-sea/tuna
+++ b/example-3/secrets/targets/prod-sea/tuna
@@ -1,3 +1,3 @@
 data: Y2JBNE9RRmhLYlZ1Mk1KVWY5a3NuX0hKMmdkNk9YTjNkVDZNaEtRUEhQYw==
 encoding: original
-type: ref
+type: plain


### PR DESCRIPTION
@ademariag 
Example-3 build was failing due to removal of "ref" in base.py. hence I changed it to "plain".

Before fix logs: 
---------------------------------------------------------------------------------------------------------
(kapitan) veer@ubuntu:~/.../kapitan-examples/example-3$ kapitan --version
0.27.0
(kapitan) veer@ubuntu:~/.../kapitan-examples/example-3$ rm -rf compiled/*
(kapitan) veer@ubuntu:~/.../kapitan-examples/example-3$ kapitan compile

no backend for ref type: ref
  for key ?{ref:targets/prod-sea/tuna|randomstr}
Compile error: failed to compile target: prod-sea
(kapitan) veer@ubuntu:~/.../kapitan-examples/example-3$ 

After fix logs:
----------------------------------------------------------------------------------------------------------------------
(kapitan) veer@ubuntu:~/.../kapitan-examples/example-3$ kapitan compile
Compiled prod-sea (0.38s)
Compiled dev-sea (0.39s)
(kapitan) veer@ubuntu:~/.../kapitan-examples/example-3$
